### PR TITLE
Suppress UIPasteBoard log and use printf for success message

### DIFF
--- a/pbcopy/pbcopy.m
+++ b/pbcopy/pbcopy.m
@@ -8,6 +8,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+// the function used by UIPasteboard to log what type of data was placed in the clipboard
+extern void _NSSetLogCStringFunction(void(*)(const char*, unsigned, BOOL));
+static void noLog(const char* message, unsigned length, BOOL withSysLogBanner) { /* Empty */ }
+
 int main (int argc, char* argv[]) {
     @autoreleasepool {
         if (argc == 2) {
@@ -30,7 +34,11 @@ int main (int argc, char* argv[]) {
         NSData *data = [[NSFileHandle fileHandleWithStandardInput] availableData];
         NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+
+        _NSSetLogCStringFunction(noLog);
         pasteboard.string = dataString;
-        NSLog(@"Data copied to clipboard.");
+        _NSSetLogCStringFunction(NULL);
+
+        printf("Data copied to clipboard.\n");
     }
 }


### PR DESCRIPTION
This pull request suppresses UIPasteBoard logging the type of data that was placed into the clipboard, it also changes the finally log to use printf instead of NSLog for cleaner output.

Output changed from this:
```
2021-11-03 18:00:00.001 pbcopy[38156:4522618] Returning local object of class NSString
2021-11-03 18:00:00.002 pbcopy[38156:4522618] Data copied to clipboard.
```

To this:
```
Data copied to clipboard.
```