### PR TITLE
pbcopy: Add support for iOS 15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-bin
+/*/pb*
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,18 @@
-.PHONY: clean all pbupload pbcopy pbpaste
+.PHONY: all clean
 
 CC     := xcrun --sdk iphoneos clang
 CFLAGS := -O2 -arch arm64 -fobjc-arc -miphoneos-version-min=10.0
 LIBS   := -framework Foundation -framework UIKit
 SIGN   := ldid -Sent.plist
 
+SRC  := $(wildcard **/*.m)
+BINS := $(SRC:%.m=%)
+
+all: $(BINS)
+
+%: %.m
+	$(CC) $(CFLAGS) $< -o $@ $(LIBS)
+	$(SIGN) $@
+
 clean:
-	rm -rf bin/
-
-all: pbupload pbcopy pbpaste
-
-pbupload:
-	$(CC) $(CFLAGS) pbupload/pbupload.m -o bin/pbupload $(LIBS)
-	$(SIGN) bin/pbupload
-
-pbcopy:
-	$(CC) $(CFLAGS) pbcopy/pbcopy.m -o bin/pbcopy $(LIBS)
-	$(SIGN) bin/pbcopy
-
-pbpaste:
-	$(CC) $(CFLAGS) pbpaste/pbpaste.m -o bin/pbpaste $(LIBS)
-	$(SIGN) bin/pbpaste
+	rm -rf $(BINS)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: all clean
+.PHONY: all install clean
+
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
 
 CC     := xcrun --sdk iphoneos clang
-CFLAGS := -O2 -arch arm64 -fobjc-arc -miphoneos-version-min=10.0
+CFLAGS ?= -O2 -arch arm64 -fobjc-arc -miphoneos-version-min=10.0
 LIBS   := -framework Foundation -framework UIKit
 SIGN   := ldid -Sent.plist
 
@@ -13,6 +16,10 @@ all: $(BINS)
 %: %.m
 	$(CC) $(CFLAGS) $< -o $@ $(LIBS)
 	$(SIGN) $@
+
+install:
+	install -d $(DESTDIR)$(BINDIR)
+	install -m755 $(BINS) $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -rf $(BINS)

--- a/ent.plist
+++ b/ent.plist
@@ -7,5 +7,7 @@
 	<true/>
 	<key>com.apple.private.skip-library-validation</key>
 	<true/>
+	<key>com.apple.Pasteboard.background-access</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
iOS 15 requires a new entitlement for pasteboard-utils to work properly. On top of that, the Makefile was rewritten, only using one target rule to compile all projects (within their respective project directory) and to include an install rule.